### PR TITLE
Fix URL generation (sputnik:make_url).

### DIFF
--- a/sputnik/lua/sputnik/actions/collections.lua
+++ b/sputnik/lua/sputnik/actions/collections.lua
@@ -21,10 +21,10 @@ local function format_list(nodes, template, sputnik, node, request)
             do_nodes = function()
                           for i, node in ipairs(nodes) do
                              local t = {
-                                url = sputnik.config.NICE_URL..node.id,
+                                url = sputnik:make_url(node.id),
                                 id  = node.id,
                                 short_id = node.id:match("[^%/]*$"),
-                                nice_url = sputnik.config.NICE_URL,
+                                nice_url = sputnik.config.BASE_URL,
                              }
                              for k, v in pairs(node.fields) do
                                  t[k] = tostring(node[k])
@@ -103,10 +103,10 @@ function actions.show(node, request, sputnik)
          for i, node in ipairs(non_proto_nodes) do
              sputnik:decorate_node(node)
             local t = {
-               url = sputnik.config.NICE_URL..node.id,
+               url = sputnik:make_url(node.id),
                id  = node.id,
                short_id = node.id:match("[^%/]*$"),
-               nice_url = sputnik.config.NICE_URL,
+               nice_url = sputnik.config.BASE_URL,
                logged_in_user = request.user,
             }
             for k, v in pairs(node.fields) do

--- a/sputnik/lua/sputnik/actions/search.lua
+++ b/sputnik/lua/sputnik/actions/search.lua
@@ -61,7 +61,7 @@ actions.show_results = function(node, request, sputnik)
                                          cosmo.yield {
                                             name = node.id:gsub("_", " "),
                                             title = node.title,
-                                            url = sputnik.config.NICE_URL..node.id,
+                                            url = sputnik:make_url(node.id),
                                             --backlinks = weights[node.id] or 0,
                                             snippet = "", --snippets[id],
                                             time = sputnik:format_time(metadata.timestamp, "%Y/%m/%d")

--- a/sputnik/lua/sputnik/actions/wiki.lua
+++ b/sputnik/lua/sputnik/actions/wiki.lua
@@ -327,7 +327,7 @@ function actions.show(node, request, sputnik)
    if node.is_a_stub then
       request.is_indexable = false
       node.inner_html = cosmo.f(node.templates.NEW_NODE){
-         icon_base_url = sputnik.config.ICON_BASE_URL or sputnik.config.NICE_URL,
+         icon_base_url = sputnik.config.ICON_BASE_URL or sputnik.config.BASE_URL,
          edit_url = sputnik:make_url(node.id, "edit_new"),
          do_prototypes = function()
                             local prototypes = sputnik.config.NEW_NODE_PROTOTYPES or {}
@@ -654,7 +654,7 @@ function actions.list_nodes(node, request, sputnik)
                                       for i, node in ipairs(nodes) do
                                          cosmo.yield {
                                             name  = node.id,
-                                            url = sputnik.config.NICE_URL..node.id
+                                            url = sputnik:make_url(node.id)
                                          }
                                       end
                         end,
@@ -675,7 +675,7 @@ function actions.show_sitemap_xml(node, request, sputnik)
                 url = sputnik.config.HOME_PAGE_URL
                 priority = "0.9"
              else
-                url = sputnik.config.NICE_URL..node.id
+                url = sputnik:make_url(node.id)
                 priority = "0.1"
              end
              cosmo.yield{
@@ -1228,9 +1228,9 @@ function wrappers.default(node, request, sputnik)
 
       -- "links" include "href="
       show_link        = sputnik:make_link(node.id),
-      icon_base_url    = sputnik.config.ICON_BASE_URL or sputnik.config.NICE_URL,
-      css_base_url     = sputnik.config.CSS_BASE_URL or sputnik.config.NICE_URL,
-      js_base_url      = sputnik.config.JS_BASE_URL or sputnik.config.NICE_URL,
+      icon_base_url    = sputnik.config.ICON_BASE_URL or sputnik.config.BASE_URL.."?p=",
+      css_base_url     = sputnik.config.CSS_BASE_URL or sputnik.config.BASE_URL.."?p=",
+      js_base_url      = sputnik.config.JS_BASE_URL or sputnik.config.BASE_URL.."?p=",
       do_toolbar       = function(args)
                             local icons = sputnik.config.TOOLBAR_ICONS
                             for i, command in ipairs(sputnik.config.TOOLBAR_COMMANDS) do
@@ -1254,7 +1254,7 @@ function wrappers.default(node, request, sputnik)
                             return sputnik:make_url(unpack(args))
                          end,
       base_url         = sputnik.config.BASE_URL, -- for mods
-      nice_url         = sputnik.config.NICE_URL, -- for mods
+      nice_url         = (base_url or "").."?p=", --sputnik.config.NICE_URL, -- for mods
       home_page_url    = sputnik.config.HOME_PAGE_URL,
       logo_url         = sputnik.config.LOGO_URL,
       favicon_url      = sputnik.config.FAVICON_URL,

--- a/sputnik/lua/sputnik/init.lua
+++ b/sputnik/lua/sputnik/init.lua
@@ -26,6 +26,7 @@ module(..., package.seeall)
 
 require("md5")
 require("wsapi.util")
+require('wsapi.request')
 require("cosmo")
 require("saci")
 require("sputnik.actions.wiki")
@@ -878,11 +879,12 @@ function Sputnik:make_url(node_name, action, params, anchor)
    end
 
    local dirified = self:dirify(node_name) --wsapi.util.url_encode()
+   local url, node
+   local params = params or {}
 
-   local url
-
-   -- first the node name
+   -- interwiki urls
    if interwiki_handler then
+      -- first the node name
       local handler_type = type(interwiki_handler)
       if handler_type == "string" then
          if interwiki_handler:match("%%s") then
@@ -895,29 +897,36 @@ function Sputnik:make_url(node_name, action, params, anchor)
       else
          error("Interwiki handler should be string or function, but is "..handler_type)
       end
-   else
-      url = self.config.NICE_URL..dirified
-   end
 
-   -- then the action and HOME_PAGE
-   if action and action~="show" then 
-      url = url.."."..action
-   elseif dirified==self.config.HOME_PAGE and #(params or {})==0 then
-      url = self.config.HOME_PAGE_URL
-   end
-
-   -- then the parameters
-   if params and next(params) then
-
-      for k, v in pairs(params or {}) do
-         if k~="p" then
-            url = url.."&"..wsapi.util.url_encode(k).."="
-                          ..wsapi.util.url_encode(v or "")
-         end
+      -- then the action
+      if action and action~="show" then
+         url = url.."."..action
+      elseif dirified == self.config.HOME_PAGE then
+         url = self.config.HOME_PAGE_URL
       end
+
+   else
+      -- concatenate the action to the node_name
+      if action and action ~= "show" then
+         node = dirified.."."..action
+      else
+         node = dirified
+      end
+
+      -- url without query string
+      if self.config.USE_NICE_URL then
+         url = self.config.BASE_URL..node
+      else
+         url = self.config.BASE_URL
+         params["p"] = node
+      end
+
+      -- encode query string and create url
+      url = url .. wsapi.request.methods:qs_encode(params)
    end
 
-   -- finally the anchor
+
+   -- finally add the anchor
    if anchor then
       url = url.."#"..anchor
    end

--- a/sputnik/lua/sputnik/node_defaults/index.lua
+++ b/sputnik/lua/sputnik/node_defaults/index.lua
@@ -30,9 +30,9 @@ After that, logged in as "Admin", you can do some customizations.  See node
 [[sputnik]] for the complete list of options, but here are some basic ideas:
 
 Edit [[sputnik/config.edit]] node to change the title of your wiki and the domain
-of your server.  While there, you can also edit the ``NICE_URL`` parameter to
-whatever you want the your "short" URLs to start with.  E.g., if you set it to
-"/mysite/" your wikilinks will point to "/mysite/Page_Name".
+of your server.  While there, you can also set the ``USE_NICE_URL`` to ``true``
+and edit the ``BASE_URL``parameter to whatever you want to use shorter URLs.
+E.g., if you set it to "/mysite/" your wikilinks will point to "/mysite/Page_Name".
 
 Also, edit the [[sputnik/navigation.edit]] page to set your navigation bar.
 If you are new to Lua, don't get scared.  Use the "preview" button to check

--- a/sputnik/lua/sputnik/node_defaults/sputnik/config.lua
+++ b/sputnik/lua/sputnik/node_defaults/sputnik/config.lua
@@ -7,15 +7,15 @@ NODE = {
 
 NODE.content = [=============[
 
-SITE_TITLE     = "Sputnik"        -- change the title of the site
+SITE_TITLE     = "Sputnik"            -- change the title of the site
 SITE_SUBTITLE  = "An extensible wiki in Lua"       -- change the subtitle of the site
 DOMAIN         = "localhost:8080"     -- set for RSS feeds to work properly
-NICE_URL       = BASE_URL.."?p="      -- set if you want "nicer" URLs
+--USE_NICE_URL   = false                -- set if you want "nicer" URLs
 MAIN_COLOR     = 200                  -- pick a number from 0 to 360
 --BODY_BG_COLOR  = "white"
 
 HOME_PAGE      = "index"
-HOME_PAGE_URL  = NICE_URL             -- or NICE_URL.."?p="..HOME_PAGE
+HOME_PAGE_URL  = BASE_URL             -- or BASE_URL.."?p="..HOME_PAGE
 COOKIE_NAME    = "Sputnik"            -- change if you run several
 
 --SEARCH_CONTENT = "Installation"

--- a/sputnik/lua/sputnik/node_defaults/sputnik/config_defaults.lua
+++ b/sputnik/lua/sputnik/node_defaults/sputnik/config_defaults.lua
@@ -18,12 +18,12 @@ NODE.content = [=============[
 SITE_TITLE     = "My New Wiki"        -- change the title of the site
 SITE_SUBTITLE  = "Don't panic!"       -- change the subtitle of the site
 DOMAIN         = "localhost:8080"     -- set for RSS feeds to work properly
-NICE_URL       = BASE_URL.."?p="      -- set if you want "nicer" URLs
+--USE_NICE_URL   = false
 MAIN_COLOR     = 200                  -- pick a number from 0 to 360
 --BODY_BG_COLOR  = "white"
 
 HOME_PAGE      = "index"
-HOME_PAGE_URL  = NICE_URL             -- or NICE_URL.."?p="..HOME_PAGE
+HOME_PAGE_URL  = BASE_URL             -- or BASE_URL.."?p="..HOME_PAGE
 COOKIE_NAME    = "Sputnik"            -- change if you run several
 SEARCH_PAGE    = "search"             -- comment out remove the search box
 
@@ -36,9 +36,9 @@ TIME_ZONE_NAME = "<abbr title='Greenwich Mean Time'>GMT</abbr>"
 --------- URLs --------------------------------------------------------------
 -----------------------------------------------------------------------------
 
-ICON_BASE_URL  = NICE_URL             -- change this to host icons elsewhere
-CSS_BASE_URL   = NICE_URL             -- change this to host CSS elsewhere
-JS_BASE_URL    = NICE_URL             -- change this to host JS elsewhere
+ICON_BASE_URL  = BASE_URL.."?p="             -- change this to host icons elsewhere
+CSS_BASE_URL   = BASE_URL.."?p="             -- change this to host CSS elsewhere
+JS_BASE_URL    = BASE_URL.."?p="             -- change this to host JS elsewhere
 LOGO_URL       = ICON_BASE_URL.."logo.png"
 FAVICON_URL    = ICON_BASE_URL.."icons/sputnik.png"
 


### PR DESCRIPTION
Now the "nice" urls are created with a valid query string:

   http://localhost/wiki/sputnik/login?next=sputnik%2Fregister

instead of:

   http://localhost/wiki/sputnik/login&next=sputnik%2Fregister

The config variable NICE_URL (string) has been changed to USE_NICE_URL
(boolean) and the following strategy has been used for creating the URL:

```
   if USE_NICE_URL then
      -- e.g. http://localhost/wiki/somepage.edit
      url  = BASE_URL + node_id + "." + action
   else
      -- put node_id + "." + action as a parameter
      -- e.g. http://localhost/cgi-bin/sputnik.cgi?p=somepage.edit
      url = self.config.BASE_URL
      params["p"] = node
   end
   -- encode query string and create url
   url = wsapi.request.methods:link(url, params)
```

Also, the index node content has been changed to explain the new config
variable.

**Note:** since this commit is necessary to use wsapi 1.5.

**More info:**
http://lists.luaforge.net/pipermail/sputnik-list/2011-August/thread.html
http://groups.google.com/group/sputnik-list/browse_thread/thread/ff3d0ba7f7665c7f
