### PR TITLE
Set cosmo to require cosmo

### DIFF
--- a/installer/installer/lua/sputnik/installer.lua
+++ b/installer/installer/lua/sputnik/installer.lua
@@ -1,7 +1,7 @@
 module(..., package.seeall)
 
 require"lfs"
-require"cosmo"
+cosmo=require"cosmo"
 
 REQUIRE_LUAROCKS = [[pcall(require, "luarocks.require")]]
 


### PR DESCRIPTION
Cosmo does not export to the cosmo variable by default.  This must be set with cosmo=require "cosmo".
